### PR TITLE
adding week03 work and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### What is included in the PR?
+
+--------------------------------------------------------------------------------
+### Explain the changes being made.
+### What difficulties you ran into, and the resulting architectural choices you made, while doing the assignment?
+### While surprises did you find while doing the assignment?

--- a/week03/assignment03.go
+++ b/week03/assignment03.go
@@ -1,0 +1,103 @@
+package week03
+
+import (
+	"fmt"
+)
+
+var (
+	ErrRatingNoPlays       = fmt.Errorf("can't review a movie without watching it first")
+	ErrInvalidViewersValue = fmt.Errorf("invalid number of viewers, must be greather than 0")
+	ErrTeatherPlayNoMovies = fmt.Errorf("no movies to play")
+)
+
+type (
+	CritiqueFn func(Movie) (float32, error)
+
+	Movie struct {
+		Length int
+		Name   string
+
+		plays   int
+		viewers int
+		ratings []float32
+	}
+
+	Theatre struct{}
+)
+
+func (mo *Movie) Rate(rate float32) error {
+	if mo.plays == 0 {
+		return ErrRatingNoPlays
+	}
+
+	mo.ratings = append(mo.ratings, rate)
+
+	return nil
+}
+
+func (mo *Movie) Play(viewers int) error {
+	if viewers <= 0 {
+		return ErrInvalidViewersValue
+	}
+
+	mo.plays++
+	mo.viewers += viewers
+
+	return nil
+}
+
+func (mo Movie) Viewers() int {
+	return mo.viewers
+}
+
+func (mo Movie) Plays() int {
+	return mo.plays
+}
+
+func (mo Movie) Rating() float64 {
+	if len(mo.ratings) == 0 {
+		return 0.0
+	}
+
+	var total float64
+	for _, rate := range mo.ratings {
+		total += float64(rate)
+	}
+
+	return total / float64(len(mo.ratings))
+}
+
+func (mo *Theatre) Play(viewers int, movies ...*Movie) error {
+	if len(movies) == 0 {
+		return ErrTeatherPlayNoMovies
+	}
+
+	for _, mo := range movies {
+		err := mo.Play(viewers)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mo *Theatre) Critique(movies []*Movie, critique CritiqueFn) error {
+	for _, mo := range movies {
+		err := mo.Play(1)
+		if err != nil {
+			return err
+		}
+
+		rating, err := critique(*mo)
+		if err != nil {
+			return err
+		}
+
+		err = mo.Rate(rating)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/week03/assignment03.go
+++ b/week03/assignment03.go
@@ -54,6 +54,10 @@ func (mo Movie) Plays() int {
 	return mo.plays
 }
 
+func (mo Movie) String() string {
+	return fmt.Sprintf("%s (%dm) %.1f%%", mo.Name, mo.Length, mo.Rating())
+}
+
 func (mo Movie) Rating() float64 {
 	if len(mo.ratings) == 0 {
 		return 0.0

--- a/week03/assignment03.go
+++ b/week03/assignment03.go
@@ -89,17 +89,17 @@ func (mo *Theatre) Critique(movies []*Movie, critique CritiqueFn) error {
 	for _, mo := range movies {
 		err := mo.Play(1)
 		if err != nil {
-			return err
+			return fmt.Errorf("error playing on critique: %w", err)
 		}
 
 		rating, err := critique(*mo)
 		if err != nil {
-			return err
+			return fmt.Errorf("error running critique: %w", err)
 		}
 
 		err = mo.Rate(rating)
 		if err != nil {
-			return err
+			return fmt.Errorf("error rating on critique: %w", err)
 		}
 	}
 

--- a/week03/assignment03_test.go
+++ b/week03/assignment03_test.go
@@ -1,0 +1,180 @@
+package week03
+
+import (
+	"errors"
+	"testing"
+)
+
+// DONE: Define a Movie struct and export two public fields; Length of type int and Name of type string. You must NOT export any more public fields on Movie. You are allowed, however, to use non-exported, private fields as needed.
+// DONE: Define a method on the pointer receiver for Movie named Rate. Rate should take a float32 rating and return an error. Calling Rate should track this rating. If the number of plays is 0 return the following error: fmt.Errorf()
+// DONE: Define a method on the pointer receiver for Movie named Play. Play should take the number (int) of viewers watching the movie. Calling Play should increase both the number of viewers, as well as the number of plays, for the movie.
+// DONE: Define a method on the value receiver for Movie named Viewers. Viewers takes no arguments and returns the number (int) of people who have viewed the movie.
+// DONE: Define a method on the value receiver for Movie named Plays. Plays takes no arguments and returns the number (int) of times the movie has been played.
+// DONE: Define a method on the value receiver for Movie named Rating. Rating takes no arguments and returns the rating (float64) of the movie. This can be calculated by the total ratings for the movie divided by the number of times the movie has been played.
+// DONE: Define a method on the value receiver for Movie named String. String should return a string that that includes the name, length, and rating of the film. Ex. Wizard of Oz (102m) 99.0%
+// DONE  Define a new type named CritiqueFn that is a function type that takes a pointer of type Movie and returns a float32 and an error. Note: This is not a func definition, but rather a type definition.
+// DONE: Define a Theatre struct. You must not export any public fields on Theatre. You are allowed, however, to use non-exported, private fields as needed.
+
+func TestMovieRate(t *testing.T) {
+	movie := &Movie{}
+
+	t.Run("NoPlaysReturnError", func(t *testing.T) {
+		movie.plays = 0
+		err := movie.Rate(0.5)
+
+		if !errors.Is(err, ErrRatingNoPlays) {
+			t.Errorf("Expected error to be %v got %v", ErrRatingNoPlays, err)
+		}
+	})
+
+	t.Run("NoTrackRatings", func(t *testing.T) {
+		movie.plays = 1
+		err := movie.Rate(0.5)
+
+		if err != nil {
+			t.Errorf("Expected error to be nil got %v", err)
+		}
+
+		if len(movie.ratings) != 1 {
+			t.Errorf("Expected length of ratings to be 1 got %v", len(movie.ratings))
+		}
+	})
+}
+
+func TestMoviePlay(t *testing.T) {
+	movie := &Movie{}
+
+	t.Run("PlayPositive", func(t *testing.T) {
+		movie.plays = 0
+
+		err := movie.Play(100)
+		if err != nil {
+			t.Errorf("Expected error to be nil got %v", err)
+		}
+
+		if movie.plays != 1 {
+			t.Errorf("Expected plays to be 1 got %v", movie.plays)
+		}
+
+		if movie.viewers != 100 {
+			t.Errorf("Expected viewers to be 100 got %v", movie.viewers)
+		}
+	})
+
+	t.Run("PlayNegative", func(t *testing.T) {
+		movie.plays = 1
+		err := movie.Play(-10)
+
+		if err != ErrInvalidViewersValue {
+			t.Errorf("Expected error to be %v got %v", ErrInvalidViewersValue, err)
+		}
+	})
+}
+
+func TestMovieRating(t *testing.T) {
+	tcases := []struct {
+		name   string
+		values []float32
+		rating float64
+	}{
+		{"NoRating", []float32{}, 0.0},
+		{"OneRating", []float32{3.5}, 3.5},
+		{"SomeMore", []float32{3.5, 3.0, 2.5}, 3.0},
+		{"SomeMoreTwo", []float32{0.0, 5.0, 0.5, 0.0}, 1.375},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			movie := &Movie{}
+			movie.ratings = tcase.values
+
+			rating := movie.Rating()
+			if rating != tcase.rating {
+				t.Errorf("Expected rating to be %v got %v", tcase.rating, rating)
+			}
+		})
+
+	}
+}
+
+// ✅ Define a method on the pointer receiver for Theatre named Play.
+// ✅ Play should take the number (int) of viewers, a variadic list of pointer of type Movie, and return an error.
+// ✅ Calling Play will call each movie’s Play method  with the number of viewers.
+// ✅ If no movies are passed in return the following error: fmt.Errorf("no movies to play").
+func TestTeatherPlay(t *testing.T) {
+	theatre := &Theatre{}
+
+	tcases := []struct {
+		name          string
+		viewers       int
+		expectedError error
+		movies        []*Movie
+	}{
+		{"NoMovies", 100, ErrTeatherPlayNoMovies, []*Movie{}},
+		{"OneMovie", 100, nil, []*Movie{{Name: "The Mask", Length: 102}}},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			err := theatre.Play(tcase.viewers, tcase.movies...)
+			if err != tcase.expectedError {
+				t.Errorf("Expected error to be %v got %v", tcase.expectedError, err)
+			}
+
+			for _, mo := range tcase.movies {
+				if mo.plays < 1 {
+					t.Errorf("Expected plays to be greater than 0 got %v", mo.plays)
+				}
+
+				if mo.viewers != tcase.viewers {
+					t.Errorf("Expected viewers to be %v got %v", tcase.viewers, mo.viewers)
+				}
+			}
+		})
+	}
+}
+
+// ✅ Define a method on the value receiver for Theatre named Critique.
+// ✅ Critique should take a slice of pointers to type Movie, a CritiqueFn, and return an error.
+// ✅ Calling Critique will iterate over the movies and for each movie.
+// ✅ First, each movie’s Play method should be called with a value of 1.
+// ✅ Next, the CritiqueFn should be called with the movie, the return values should be error checked.
+// ✅ If there is no error the movie’s Rate method should be called with the float32 value that was returned from the CritiqueFn.
+// ✅ Again, this call should be error checked.
+func TestTeatherCritique(t *testing.T) {
+	movies := []*Movie{
+		{Name: "The Mask", Length: 102},
+		{Name: "Ace Ventura", Length: 102},
+		{Name: "The Matrix", Length: 102},
+		{Name: "The Matrix Reloaded", Length: 102},
+	}
+
+	lazyCritique := func(mo Movie) (float32, error) {
+		return 5.0, nil
+	}
+
+	theatre := &Theatre{}
+	err := theatre.Critique(movies, lazyCritique)
+
+	if err != nil {
+		t.Errorf("Expected error to be nil got %v", err)
+	}
+
+	for _, mo := range movies {
+		if mo.plays != 1 {
+			t.Errorf("Expected plays to be 1 got %v", mo.plays)
+		}
+
+		if mo.viewers != 1 {
+			t.Errorf("Expected viewers to be 1 got %v", mo.viewers)
+		}
+
+		if len(mo.ratings) != 1 {
+			t.Errorf("Expected length of ratings to be 1 got %v", len(mo.ratings))
+		}
+
+		if mo.ratings[0] != 5.0 {
+			t.Errorf("Expected rating to be 5.0 got %v", mo.ratings[0])
+		}
+	}
+}

--- a/week03/assignment03_test.go
+++ b/week03/assignment03_test.go
@@ -5,16 +5,8 @@ import (
 	"testing"
 )
 
-// DONE: Define a Movie struct and export two public fields; Length of type int and Name of type string. You must NOT export any more public fields on Movie. You are allowed, however, to use non-exported, private fields as needed.
-// DONE: Define a method on the pointer receiver for Movie named Rate. Rate should take a float32 rating and return an error. Calling Rate should track this rating. If the number of plays is 0 return the following error: fmt.Errorf()
-// DONE: Define a method on the pointer receiver for Movie named Play. Play should take the number (int) of viewers watching the movie. Calling Play should increase both the number of viewers, as well as the number of plays, for the movie.
-// DONE: Define a method on the value receiver for Movie named Viewers. Viewers takes no arguments and returns the number (int) of people who have viewed the movie.
-// DONE: Define a method on the value receiver for Movie named Plays. Plays takes no arguments and returns the number (int) of times the movie has been played.
-// DONE: Define a method on the value receiver for Movie named Rating. Rating takes no arguments and returns the rating (float64) of the movie. This can be calculated by the total ratings for the movie divided by the number of times the movie has been played.
-// DONE: Define a method on the value receiver for Movie named String. String should return a string that that includes the name, length, and rating of the film. Ex. Wizard of Oz (102m) 99.0%
-// DONE  Define a new type named CritiqueFn that is a function type that takes a pointer of type Movie and returns a float32 and an error. Note: This is not a func definition, but rather a type definition.
-// DONE: Define a Theatre struct. You must not export any public fields on Theatre. You are allowed, however, to use non-exported, private fields as needed.
-
+// ✅ Define a Movie struct and export two public fields; Length of type int and Name of type string. You must NOT export any more public fields on Movie. You are allowed, however, to use non-exported, private fields as needed.
+// ✅ Define a method on the pointer receiver for Movie named Rate. Rate should take a float32 rating and return an error. Calling Rate should track this rating. If the number of plays is 0 return the following error: fmt.Errorf()
 func TestMovieRate(t *testing.T) {
 	movie := &Movie{}
 
@@ -41,6 +33,7 @@ func TestMovieRate(t *testing.T) {
 	})
 }
 
+// ✅  Define a method on the pointer receiver for Movie named Play. Play should take the number (int) of viewers watching the movie. Calling Play should increase both the number of viewers, as well as the number of plays, for the movie.
 func TestMoviePlay(t *testing.T) {
 	movie := &Movie{}
 
@@ -71,6 +64,7 @@ func TestMoviePlay(t *testing.T) {
 	})
 }
 
+// ✅ Define a method on the value receiver for Movie named Rating. Rating takes no arguments and returns the rating (float64) of the movie. This can be calculated by the total ratings for the movie divided by the number of times the movie has been played.
 func TestMovieRating(t *testing.T) {
 	tcases := []struct {
 		name   string
@@ -97,6 +91,54 @@ func TestMovieRating(t *testing.T) {
 	}
 }
 
+// ✅ Define a method on the value receiver for Movie named Plays. Plays takes no arguments and returns the number (int) of times the movie has been played.
+func TestMoviePlays(t *testing.T) {
+	mo := Movie{}
+	if mo.Plays() != 0 {
+		t.Errorf("Expected plays to be 0 got %v", mo.Plays())
+	}
+
+	mo.plays = 100
+	if mo.Plays() != 100 {
+		t.Errorf("Expected plays to be 100 got %v", mo.Plays())
+	}
+}
+
+// ✅ Define a method on the value receiver for Movie named Viewers. Viewers takes no arguments and returns the number (int) of people who have viewed the movie.
+func TestMovieViewers(t *testing.T) {
+	mo := Movie{}
+	if mo.Viewers() != 0 {
+		t.Errorf("Expected viewers to be 0 got %v", mo.Viewers())
+	}
+
+	mo.viewers = 100
+	if mo.Viewers() != 100 {
+		t.Errorf("Expected viewers to be 100 got %v", mo.Viewers())
+	}
+}
+
+// ✅ Define a method on the value receiver for Movie named String. String should return a string that that includes the name, length, and rating of the film. Ex. Wizard of Oz (102m) 99.0%
+func TestMovieString(t *testing.T) {
+	tcases := []struct {
+		name  string
+		movie Movie
+		str   string
+	}{
+		{"NoRating", Movie{Name: "AAA"}, "AAA (0m) 0.0%"},
+		{"OneRating", Movie{Name: "The Matrix", Length: 102, ratings: []float32{3.5}}, "The Matrix (102m) 3.5%"},
+		{"MultiRating", Movie{Name: "The Matrix Reloaded", Length: 102, ratings: []float32{3.5, 100.0}}, "The Matrix Reloaded (102m) 51.8%"},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			if tcase.movie.String() != tcase.str {
+				t.Errorf("Expected string to be %v got %v", tcase.str, tcase.movie.String())
+			}
+		})
+	}
+}
+
+// ✅ Define a Theatre struct. You must not export any public fields on Theatre. You are allowed, however, to use non-exported, private fields as needed.
 // ✅ Define a method on the pointer receiver for Theatre named Play.
 // ✅ Play should take the number (int) of viewers, a variadic list of pointer of type Movie, and return an error.
 // ✅ Calling Play will call each movie’s Play method  with the number of viewers.
@@ -134,6 +176,7 @@ func TestTeatherPlay(t *testing.T) {
 	}
 }
 
+// ✅ Define a new type named CritiqueFn that is a function type that takes a pointer of type Movie and returns a float32 and an error. Note: This is not a func definition, but rather a type definition.
 // ✅ Define a method on the value receiver for Theatre named Critique.
 // ✅ Critique should take a slice of pointers to type Movie, a CritiqueFn, and return an error.
 // ✅ Calling Critique will iterate over the movies and for each movie.


### PR DESCRIPTION
### What is included in the PR?
This PR includes week03 work. It adds in there the Movie, Theatre and CritiqueFn types, these are intended to support the purposed model in our assessment #3.
--------------------------------------------------------------------------------
### Explain the changes being made.
Inside the assessment code I created structs as requested, I did define a couple of extra un-exported fields in the Movie struct to support the rating, viewers and play functions. besides that I added the suggested methods for the theatre which connect the three types `Movie`, `Theatre` and `CritiqueFn`.
 
### What difficulties you ran into, and the resulting architectural choices you made, while doing the assignment?
One thing I noticed is that I was not adding tests for the accessor kind of functions for Movies (Pays and Viewers), once I noticed it I decided to add them, I tried to cover a lot with the tests but feel like I did not do a very deep search for cases I might not be covering.

One architectural choice I made was defining the tests as variables in the package instead of just using them as `fmt.Errorf` directly, this allowed me to check the errors while in test mode as well as providing a bit more visibility into the kind of errors I should be returning. Talking about this I decided to change the signature of the `Play` method to return an error, I decided to to this because the method could receive a number lower than 1 which seems to be an invalid case to me, so I thought It would be good to provide this way so the API can communicate back that passed number of viewers is invalid.

One thing I decided to do is to wrap errors with `%w` in the Critique function, I remember seeing this in the [Working with Errors in Go 1.13](https://go.dev/blog/go1.13-errors) post some time ago and decided to use it, this way I'm hoping when users run `errors.Is` with errors returned this will allow to identify underlying errors and relate it with what these mean.

### While surprises did you find while doing the assignment?
In doing the assessment I found very interesting to specify the number of decimals with the `fmt` package, this was needed when doing the string representation of the Movie, had to use `fmt.Sprintf("... %.1f` which allowed me to write the `99.0` and then to write the `%` sign I had to double the sign with `%%`, that was a very nice excercise as some of the fmt tricks trend to be forgotten if one does not use them regularly.

I had to admit having everything in the same file `assessment03.go` was a bit uncomfortable for me, I trend to put every struct in files with the same name, along with the methods of the same struct, while I'm not sure this is a Go standard it makes things a loe more easy for me so having all of these in the same file was a bit unusual for me, but it was ok.

Another thing where I felt a bit lost is the creation of a separate module by adding a go.mod file in the Week03 folder, when I do that I don't get the tests in there run with the `go test -v -race -cover ./...` command specified in our Github Actions configuration, i decided to avoid adding the file but will definitely ask Mark about this. While thinking on this I think I remember that some of the content in the beginning of the course requires that we put the code within the $GOPATH, however if we initialize a module there is no need for that so I decided not to do it, I wonder if the issue I'm seeing when adding go.mod are related with that. More than that if there is a `go test` command that would test the packages found under the folder specified.

Also, I liked the use of `CritiqueFn` and that pattern got me thinking about including it more often in designs I work on, I did find this patten very nice in the Critique method and started to think about how different kind of critiques and even thinking how to implement them, while testing I thought on: "Random Critique", "HyperCrique", "AntonEgo" and their possible implementations in the shape specified by the `CritiqueFn` type. Loved it.